### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An integration that allows Claude Desktop to interact with Spotify using the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-spotify">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-spotify/badge" alt="Claude Spotify MCP server" />
+</a>
+
 ## Demo
 
 <p>


### PR DESCRIPTION
This PR adds a badge for the [MCP Claude Spotify](https://glama.ai/mcp/servers/@imprvhub/mcp-claude-spotify) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-spotify">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-spotify/badge" alt="Claude Spotify MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.