### PR TITLE
Add non-root user to prevent privilege escalation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,17 @@ COPY --from=build /app/build ./build
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/public ./public
 
+# --- START SECURITY FIX ---
+# 1. Create a dedicated group and user with no privileges
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+# 2. Change the ownership of the application files to the new user
+RUN chown -R appuser:appgroup /app
+
+# 3. Switch to the non-root user
+USER appuser
+# --- END SECURITY FIX ---
+
 # Expose port for Spotify auth callback
 EXPOSE 8888
 


### PR DESCRIPTION
## Add non-root user to prevent privilege escalation

This PR addresses a critical security vulnerability by configuring the Docker container to run as a non-root user. Previously, the container executed processes with root privileges, which could lead to privilege escalation if a malicious actor gained access. By implementing a dedicated `appuser` and `appgroup`, this change significantly enhances the security posture of the `mcp-claude-spotify` server by adhering to the principle of least privilege.

The expected impact is a more secure environment for the `mcp-claude-spotify` integration without affecting its functionality. This change mitigates the risk of an attacker gaining full control over the host system through a compromised container.

### Changes Made

1.  **Created Dedicated Non-Root User:**
    *   A new system user (`appuser`) and group (`appgroup`) are created within the Docker image. These are dedicated to running the application processes.

2.  **Adjusted Directory Ownership:**
    *   The ownership of the `/app` directory, where the application code resides, is changed to the newly created `appuser:appgroup`. This ensures that the non-root user has the necessary permissions to read and write application files.

3.  **Switched Container Execution User:**
    *   The `USER` instruction in the Dockerfile is set to `appuser`, ensuring that all subsequent commands and the final container runtime execute under the context of this non-root user instead of `root`.

### Technical Implementation

The core of this security enhancement is implemented within the `Dockerfile` by adding instructions to create the user/group and switch context:

```dockerfile
# Create a non-root user and group
RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser

# Set the working directory
WORKDIR /app

# Change ownership of the /app directory to the non-root user
# This ensures the appuser has permissions to write to the directory if needed
RUN chown -R appuser:appgroup /app

# Switch to the non-root user for subsequent commands and runtime
USER appuser

...
```

This sequence ensures that the application code is owned by `appuser` and that the container's primary process runs with the reduced privileges of `appuser`, significantly limiting the potential blast radius in case of a container compromise.

### Important Notes for Reviewers

*   **No Breaking Changes Expected:** This change is designed to be transparent to the application's functionality. The application should continue to run as expected, but now with reduced privileges.
*   **Permission Review:** Reviewers should ensure that `appuser` has all necessary permissions for the application to function correctly (e.g., writing to logs, temporary files, etc.). If the application requires specific elevated permissions for certain operations, those would need to be handled carefully (e.g., by using `sudo` with specific NOPASSWD rules, though this is generally discouraged in containers). Based on the current application, no such special permissions are anticipated.

### Impact

This enhancement significantly improves the security posture of the `mcp-claude-spotify` integration by:

*   **Mitigating Privilege Escalation:** Prevents an attacker from easily gaining root access to the host system if the container is compromised.
*   **Adhering to Least Privilege:** Ensures the application runs with only the necessary permissions, reducing the attack surface.
*   **Improving Compliance:** Aligns with best practices for container security.

Closes #11